### PR TITLE
Add custom serde support

### DIFF
--- a/flare/components/base.py
+++ b/flare/components/base.py
@@ -8,7 +8,7 @@ import hikari
 import sigparse
 
 from flare.exceptions import MissingRequiredParameterError
-from flare.internal import event_handler, serde
+from flare.internal import event_handler
 
 if t.TYPE_CHECKING:
     from flare import context
@@ -38,7 +38,7 @@ class Component(abc.ABC, t.Generic[P]):
 
         if not self.args:
             # If no args were passed, calling set() isn't necessary to construct custom_id
-            self._custom_id = self.cookie
+            self._custom_id = event_handler.active_serde.serialize(self.cookie, {}, {})
 
         event_handler.components[self.cookie] = self
 
@@ -69,7 +69,7 @@ class Component(abc.ABC, t.Generic[P]):
 
     def set(self: ComponentT, *_: P.args, **values: P.kwargs) -> ComponentT:
         new = copy.copy(self)  # Create new instance with params set
-        new._custom_id = serde.serialize(self.cookie, self.args, values)
+        new._custom_id = event_handler.active_serde.serialize(self.cookie, self.args, values)
         return new
 
     @abc.abstractmethod

--- a/flare/exceptions.py
+++ b/flare/exceptions.py
@@ -7,6 +7,14 @@ class FlareException(Exception):
     """Base exception class for all flare exceptions."""
 
 
+class SerializerError(FlareException):
+    """An exception raised when a serializer fails to serialize or deserialize."""
+
+
+class SerializerVersionViolation(SerializerError):
+    """An exception raised when a serializer fails to deserialize a custom_id due to a version mismatch."""
+
+
 class ConverterError(Exception):
     """Exception raised when there is a error with converters."""
 

--- a/flare/internal/README.md
+++ b/flare/internal/README.md
@@ -3,9 +3,11 @@
 This directory has the tools used to interact with the api. These should not be touched
 by the end user.
 
-## handle_response
+## event_handler
+
 The file containing the callback called when a interaction is received.
 
 ## serde
-This files handles the encoding and decoding of python objects to strings.
+
+This file handles the encoding and decoding of python objects to strings.
 Objects are encoded and decoded using converters. See `flare/internal.converters`.

--- a/flare/internal/event_handler.py
+++ b/flare/internal/event_handler.py
@@ -21,7 +21,7 @@ active_serde: SerdeABC = Serde()
 def install(bot: hikari.EventManagerAware, serde: SerdeABC | None = None) -> None:
     """Install flare under the given bot instance.
 
-    Parameters:
+    Args:
         bot:
             The bot to install flare under.
         serde:

--- a/flare/internal/event_handler.py
+++ b/flare/internal/event_handler.py
@@ -3,6 +3,7 @@ import typing as t
 import hikari
 
 from flare.context import Context
+from flare.exceptions import SerializerError
 from flare.internal.serde import Serde
 
 __all__: t.Final[t.Sequence[str]] = ("install",)
@@ -38,7 +39,10 @@ async def _on_inter(event: hikari.InteractionCreateEvent) -> None:
     if not isinstance(event.interaction, hikari.ComponentInteraction):
         return
 
-    component, kwargs = active_serde.deserialize(event.interaction.custom_id, components)
+    try:
+        component, kwargs = active_serde.deserialize(event.interaction.custom_id, components)
+    except SerializerError:  # If the custom_id is invalid, it was probably not created by flare.
+        return
 
     ctx = Context(
         interaction=event.interaction,

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -124,7 +124,7 @@ class Serde(SerdeABC):
     def split_on_sep(self, string: str) -> list[str]:
         """Split the provided string on the separator, but ignore separators that are escaped.
 
-        Parameters:
+        Args:
             string:
                 The provided string.
 

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -48,7 +48,7 @@ class Serde:
     @property
     def VER(self) -> str | None:
         """
-        The version of the serialization format. 
+        The version of the serialization format.
         If None, the serializer will not attempt to verify the version of the serialized data.
         """
         return self._VER
@@ -116,12 +116,12 @@ class Serde:
             map:
                 A dictionary of cookies to components.
         """
-        if self.VER: # Allow for no version to disable verification
+        if self.VER:  # Allow for no version to disable verification
             version = custom_id[0]
 
             if version != self.VER:
                 raise FlareException(f"Serializer {self.__class__.__name__} cannot deserialize version {version}.")
-            
+
             custom_id = custom_id[1:]
 
         cookie, *args = self.split_on_sep(custom_id)

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -81,23 +81,23 @@ class Serde:
         return ret
 
     def deserialize(
-        self, id: str, map: dict[str, typing.Any]
+        self, custom_id: str, map: dict[str, typing.Any]
     ) -> tuple[base.Component[typing.Any], dict[str, typing.Any]]:
         """
         Decode a custom_id for a component.
 
         Args:
-            id:
+            custom_id:
                 The custom_id of the component.
             map:
                 A dictionary of cookies to components.
         """
-        version = id[0]
+        version = custom_id[0]
 
         if version != self.VER:
             raise FlareException(f"Serializer {self.__class__.__name__} cannot deserialize version {version}.")
 
-        cookie, *args = self.split_on_sep(id)[1:]
+        cookie, *args = self.split_on_sep(custom_id[1:])
 
         component_ = map[cookie]
         types = component_.args

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -3,85 +3,110 @@ from __future__ import annotations
 import typing
 
 from flare.converters import get_converter
+from flare.exceptions import FlareException
 
 if typing.TYPE_CHECKING:
     from flare.components import base
 
-__all__: typing.Final[typing.Sequence[str]] = ("serialize", "deserialize")
-
-SEP = "\x01"
-ESC = "\\"
-ESC_SEP = "\\\x01"
-NULL = "\x00"
-ESC_NULL = "\\\x00"
+__all__: typing.Final[typing.Sequence[str]] = ("Serde",)
 
 
-def serialize(cookie: str, types: dict[str, typing.Any], kwargs: dict[str, typing.Any]) -> str:
-    """
-    Encode a custom_id for a component.
+class Serde:
+    """A class that handles serialization and deserialization of components."""
 
-    Args:
-        cookie:
-            A unique identifier for the component.
-        types:
-            A dictionary of argument names to argument type hints. The type hint
-            is used to encode a value to a string.
-        kwargs:
-            Values that the user passes to save state.
-    """
-    out = f"{cookie}{SEP}"
+    @property
+    def SEP(self) -> str:
+        return "\x01"
 
-    for k, v in types.items():
-        val = kwargs.get(k)
-        converter = get_converter(v)
-        out += (
-            f"{(converter.to_str(val).replace(NULL, ESC_NULL) if val is not None else NULL).replace(SEP, ESC_SEP)}{SEP}"
-        )
+    @property
+    def ESC(self) -> str:
+        return "\\"
 
-    return out[:-1]
+    @property
+    def NULL(self) -> str:
+        return "\x00"
 
+    @property
+    def ESC_NULL(self) -> str:
+        return f"{self.ESC}\x00"
 
-def split_on_sep(s: str) -> list[str]:
-    out: list[list[str]] = [[s[0]]]
+    @property
+    def ESC_SEP(self) -> str:
+        return f"{self.ESC}\x01"
 
-    for last, char in zip(s[:-1], s[1:]):
-        if last != ESC and char == SEP:
-            out.append([])
-        else:
-            out[-1] += [char]
+    @property
+    def VER(self) -> str:
+        """The version of the serialization format."""
+        return "0"
 
-    return ["".join(row).replace(ESC_SEP, SEP) for row in out]
+    def serialize(self, cookie: str, types: dict[str, typing.Any], kwargs: dict[str, typing.Any]) -> str:
+        """
+        Encode a custom_id for a component.
 
+        Args:
+            cookie:
+                A unique identifier for the component.
+            types:
+                A dictionary of argument names to argument type hints. The type hint
+                is used to encode a value to a string.
+            kwargs:
+                Values that the user passes to save state.
+        """
+        out = f"{self.VER}{cookie}{self.SEP}"
 
-def _cast_kwargs(kwargs: dict[str, typing.Any], types: dict[str, typing.Any]) -> dict[str, typing.Any]:
-    ret: dict[str, typing.Any] = {}
-    for k, v in kwargs.items():
-        cast_to = types[k]
-        ret[k] = get_converter(cast_to).from_str(v)
+        for k, v in types.items():
+            val = kwargs.get(k)
+            converter = get_converter(v)
+            out += f"{(converter.to_str(val).replace(self.NULL, self.ESC_NULL) if val is not None else self.NULL).replace(self.SEP, self.ESC_SEP)}{self.SEP}"
 
-    return ret
+        return out[:-1]
 
+    def split_on_sep(self, s: str) -> list[str]:
+        out: list[list[str]] = [[s[0]]]
 
-def deserialize(id: str, map: dict[str, typing.Any]) -> tuple[base.Component[typing.Any], dict[str, typing.Any]]:
-    """
-    Decode a custom_id for a component.
+        for last, char in zip(s[:-1], s[1:]):
+            if last != self.ESC and char == self.SEP:
+                out.append([])
+            else:
+                out[-1] += [char]
 
-    Args:
-        id:
-            The custom_id of the component.
-        map:
-            A dictionary of cookies to components.
-    """
-    cookie, *args = split_on_sep(id)
+        return ["".join(row).replace(self.ESC_SEP, self.SEP) for row in out]
 
-    component_ = map[cookie]
-    types = component_.args
+    def _cast_kwargs(self, kwargs: dict[str, typing.Any], types: dict[str, typing.Any]) -> dict[str, typing.Any]:
+        ret: dict[str, typing.Any] = {}
+        for k, v in kwargs.items():
+            cast_to = types[k]
+            ret[k] = get_converter(cast_to).from_str(v)
 
-    transformed_args: dict[str, typing.Any] = {}
+        return ret
 
-    for k, arg in zip(types.keys(), args):
-        if arg != NULL:
-            arg = arg.replace(ESC_NULL, NULL)
-            transformed_args[k] = arg
+    def deserialize(
+        self, id: str, map: dict[str, typing.Any]
+    ) -> tuple[base.Component[typing.Any], dict[str, typing.Any]]:
+        """
+        Decode a custom_id for a component.
 
-    return (component_, _cast_kwargs(transformed_args, component_.args))
+        Args:
+            id:
+                The custom_id of the component.
+            map:
+                A dictionary of cookies to components.
+        """
+        version = id[0]
+
+        if version != self.VER:
+            raise FlareException(f"Serializer {self.__class__.__name__} cannot deserialize version {version}.")
+
+        cookie, *args = self.split_on_sep(id)[1:]
+
+        component_ = map[cookie]
+        types = component_.args
+
+        transformed_args: dict[str, typing.Any] = {}
+
+        for k, arg in zip(types.keys(), args):
+            if arg != self.NULL:
+                arg = arg.replace(self.ESC_NULL, self.NULL)
+                transformed_args[k] = arg
+
+        return (component_, self._cast_kwargs(transformed_args, component_.args))

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -20,6 +20,9 @@ class Serde:
         self._NULL: str = null
         self._VER: str | None = version
 
+        if version and len(version) != 1:
+            raise ValueError("Serde version must be a single character.")
+
     @property
     def SEP(self) -> str:
         """The separator used to separate arguments."""

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -61,10 +61,20 @@ class Serde:
 
         return out[:-1]
 
-    def split_on_sep(self, s: str) -> list[str]:
-        out: list[list[str]] = [[s[0]]]
+    def split_on_sep(self, string: str) -> list[str]:
+        """Split the provided string on the separator, but ignore separators that are escaped.
 
-        for last, char in zip(s[:-1], s[1:]):
+        Parameters:
+            string:
+                The provided string.
+
+        Returns:
+            list[str]
+                The split string.
+        """
+        out: list[list[str]] = [[string[0]]]
+
+        for last, char in zip(string[:-1], string[1:]):
             if last != self.ESC and char == self.SEP:
                 out.append([])
             else:

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -105,7 +105,8 @@ class Serde(SerdeABC):
         return self._VER
 
     def serialize(self, cookie: str, types: dict[str, typing.Any], kwargs: dict[str, typing.Any]) -> str:
-        out = f"{get_converter(int).to_str(self.VER)}{cookie}{self.SEP}"
+        version = "" if self.VER is None else get_converter(int).to_str(self.VER)
+        out = f"{version}{cookie}{self.SEP}"
 
         for k, v in types.items():
             val = kwargs.get(k)

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -110,7 +110,8 @@ class Serde(SerdeABC):
         for k, v in types.items():
             val = kwargs.get(k)
             converter = get_converter(v)
-            out += f"{(converter.to_str(val).replace(self.NULL, self.ESC_NULL) if val is not None else self.NULL).replace(self.SEP, self.ESC_SEP)}{self.SEP}"
+            val = converter.to_str(val).replace(self.NULL, self.ESC_NULL) if val is not None else self.NULL
+            out += f"{val.replace(self.SEP, self.ESC_SEP)}{self.SEP}"
 
         out = out[:-1]
 

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -57,7 +57,7 @@ class Serde(SerdeABC):
         self._SEP: str = sep
         self._ESC: str = esc
         self._NULL: str = null
-        self._VER: int = version or 0
+        self._VER: int | None = version
 
         if len(sep) != 1:
             raise ValueError("Separator must be a single character.")
@@ -97,7 +97,7 @@ class Serde(SerdeABC):
         return f"{self.ESC}{self.SEP}"
 
     @property
-    def VER(self) -> int:
+    def VER(self) -> int | None:
         """
         The version of the serialization format.
         If None, the serializer will not attempt to verify the version of the serialized data.

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -12,7 +12,7 @@ __all__: typing.Final[typing.Sequence[str]] = ("Serde",)
 
 
 class Serde:
-    """A class that handles serialization and deserialization of components."""
+    """A class that handles serialization and deserialization of component custom_id encoded data."""
 
     def __init__(self, sep: str = "\x01", null: str = "\x00", esc: str = "\\", version: str | None = "0") -> None:
         self._SEP: str = sep


### PR DESCRIPTION
Add support for custom serializers, as users (such as myself) may have previously used different formats to serialize & deserialize their custom_id and may want their components to continue working with flare.

This PR also adds a version char as the first character of the custom_id, so different serializers can be prevented from deserializing a different format they may not be expected to handle. Note that using serde versioning is optional and if a custom serializer is created with the version character set to `None`, then version checking will be disabled.

Note: I haven't tested if any of this works.